### PR TITLE
Chore/30: use ggircs PGO cluster settings

### DIFF
--- a/helm/cas-data-warehouse/templates/cronjobs/cron-swrs-import.yaml
+++ b/helm/cas-data-warehouse/templates/cronjobs/cron-swrs-import.yaml
@@ -1,4 +1,4 @@
-{{ $ggircs := (lookup "v1" "Secret" .Release.Namespace .Values.import.ggircs.secretName) }}
+{{ $ggircs := (lookup "v1" "Secret" (printf "%s-%s" .Values.import.ggircs.namespace .Values.environment) .Values.import.ggircs.secretName) }}
 
 apiVersion: batch/v1
 kind: CronJob
@@ -53,11 +53,11 @@ spec:
                       key: port
                       name: {{ template "cas-data-warehouse.fullname" . }}-pg-pguser-datawarehouse
                 - name: GGIRCS_USER
-                  value: {{ index $ggircs.data "database-user" | b64dec }}
+                  value: {{ index $ggircs.data "user" | b64dec }}
                 - name: GGIRCS_PASSWORD
-                  value: {{ index $ggircs.data "database-password" | b64dec }}
+                  value: {{ index $ggircs.data "password" | b64dec }}
                 - name: GGIRCS_DATABASE
-                  value: {{ index $ggircs.data "database-name" | b64dec }}
+                  value: {{ index $ggircs.data "dbname" | b64dec }}
                 - name: GGIRCS_PORT
                   value: "5432"
                 - name: GGIRCS_HOST

--- a/helm/cas-data-warehouse/values.yaml
+++ b/helm/cas-data-warehouse/values.yaml
@@ -6,9 +6,9 @@ import:
     namespace: d193ca
     secretName: cas-obps-postgres-pguser-registration
   ggircs:
-    service: cas-ggircs-patroni
+    service: cas-ggircs-db-cas-postgres-cluster-replicas
     namespace: 9212c9
-    secretName: cas-ggircs
+    secretName: cas-ggircs-db-cas-postgres-cluster-pguser-ggircs
   ciip:
     service: cas-ciip-portal-patroni
     namespace: 09269b


### PR DESCRIPTION
Addresses #30. Updates Data Warehouse to ingest from newly deployed PGO-based GGIRCS database cluster. 

## Changes 🚧

- Update values and env to target PGO cluster