### PR TITLE
chore: drop fetch_and_save for Dag import

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 gitsha1=$(git rev-parse HEAD)
-dagConfig=$(echo "{\"org\": \"bcgov\", \"repo\": \"cas-data-warehouse\", \"ref\": \"$gitsha1\", \"path\": \"dags/cas_data_warehouse_import_data_sources.py\"}" | base64 -w0); 
 
 helm dep up ./helm/cas-data-warehouse
 helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
@@ -15,5 +14,4 @@ helm upgrade --install --timeout 900s \
   --namespace "$CIIP_NAMESPACE_PREFIX-$ENVIRONMENT" \
   -f ./helm/cas-data-warehouse/values.yaml \
   -f "./helm/cas-data-warehouse/values-$ENVIRONMENT.yaml" \
-  --set download-cas-data-warehouse-dags.dagConfiguration="$dagConfig" \
   cas-data-warehouse ./helm/cas-data-warehouse 

--- a/helm/cas-data-warehouse/Chart.lock
+++ b/helm/cas-data-warehouse/Chart.lock
@@ -5,8 +5,5 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
-digest: sha256:a48c3b956d55cab60719a8d2829c93f8628222ce5f9936cbd93bc572676f0479
-generated: "2025-10-10T15:14:32.180466316-06:00"
+digest: sha256:8726974ce203ac7f19f3acaee705bb5bd18e876729e2c76b7983f184ec54473d
+generated: "2026-07-17T14:34:22.984802922-06:00"

--- a/helm/cas-data-warehouse/Chart.yaml
+++ b/helm/cas-data-warehouse/Chart.yaml
@@ -14,9 +14,5 @@ dependencies:
   - name: cas-airflow-dag-trigger
     version: 1.2.2
     repository: https://bcgov.github.io/cas-airflow
-    alias: download-cas-data-warehouse-dags
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
     alias: import-data-sources-dag
     condition: runImport

--- a/helm/cas-data-warehouse/values-dev.yaml
+++ b/helm/cas-data-warehouse/values-dev.yaml
@@ -1,5 +1,2 @@
 
 environment: dev
-
-download-cas-data-warehouse-dags:
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca

--- a/helm/cas-data-warehouse/values-prod.yaml
+++ b/helm/cas-data-warehouse/values-prod.yaml
@@ -1,9 +1,6 @@
 
 environment: prod
 
-download-cas-data-warehouse-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
 pg:
   postgresCluster:
     storageSize: 30Gi

--- a/helm/cas-data-warehouse/values-test.yaml
+++ b/helm/cas-data-warehouse/values-test.yaml
@@ -1,9 +1,6 @@
 
 environment: test
 
-download-cas-data-warehouse-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
 pg:
   postgresCluster:
     storageSize: 30Gi

--- a/helm/cas-data-warehouse/values.yaml
+++ b/helm/cas-data-warehouse/values.yaml
@@ -15,12 +15,6 @@ import:
 
 runImport: false
 
-download-cas-data-warehouse-dags:
-  airflowEndpoint: ~
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
 pg:
   postgresCluster:
     postgresVersion: 17


### PR DESCRIPTION
Addresses #4715. Removes legacy method of getting Dags into Airflow, once bcgov/cas-airflow#231 is merged.

## Changes 🚧

- Remove old fetch and save from chart deployments.
